### PR TITLE
FIX: store value operand was missing

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg/mod.rs
@@ -487,17 +487,19 @@ impl<'a> DFGBuilder {
                     color += 1;
                 }
                 Operator::I32Store { .. } | Operator::I64Store { .. } => {
+                    let value = self.pop_operand(idx, false);
                     let offset = self.pop_operand(idx, false);
                     let idx = self.push_node(
-                        StackType::IndexAtCode(idx, 1),
+                        StackType::IndexAtCode(idx, 2),
                         idx,
-                        vec![offset],
+                        vec![offset, value],
                         color,
                         // Add type here
                         PrimitiveTypeInfo::Empty,
                     );
 
                     self.parents[offset] = idx as i32;
+                    self.parents[value] = idx as i32;
                     color += 1;
                 }
                 // All memory loads


### PR DESCRIPTION
The fuzz target found a really dummy bug. The store operation was taking into account only the offset operand from the stack, excluding the value to be stored.

I created the PR to your branch since it is the one proposed to merge in the main branch of wasm-tools :)