### PR TITLE
FIX: Prevent to bypass function body reader

### DIFF
--- a/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
+++ b/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
@@ -18,6 +18,7 @@ impl Mutator for FunctionBodyUnreachable {
         let count = reader.get_count();
         let function_to_mutate = rnd.gen_range(0, count);
         (0..count).for_each(|i| {
+            let f = reader.read().unwrap();
             if i == function_to_mutate {
                 log::debug!("Changing function idx {:?}", i);
                 let locals = vec![];
@@ -27,7 +28,6 @@ impl Mutator for FunctionBodyUnreachable {
 
                 codes.function(&f);
             } else {
-                let f = reader.read().unwrap();
                 codes.raw(&code_section.data[f.range().start..f.range().end]);
             }
         });

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -22,6 +22,7 @@ impl Mutator for SnipMutator {
             info.get_functype_idx((function_to_mutate + info.imported_functions_count) as usize);
 
         (0..count).for_each(|i| {
+            let f = reader.read().unwrap();
             if i == function_to_mutate {
                 log::debug!("Snip function idx {:?}", function_to_mutate);
                 let locals = vec![];
@@ -54,7 +55,6 @@ impl Mutator for SnipMutator {
 
                 codes.function(&f);
             } else {
-                let f = reader.read().unwrap();
                 codes.raw(&code_section.data[f.range().start..f.range().end]);
             }
         });


### PR DESCRIPTION
This time it comes from the `wasm-mutate-stats`. For the `snip` and `set_unreachable` mutators, if the function index was mutated, the reader was not called, thus, this provokes a shift in the function types assigning during encoding. The hotfix is to always gather the function_body reader even when the function building does not use it. 